### PR TITLE
Set default CFA to stack register.

### DIFF
--- a/gas/ChangeLog.or1k
+++ b/gas/ChangeLog.or1k
@@ -1,3 +1,11 @@
+2013-01-22  Christian Svensson  <blue@cmd.nu>
+
+	* config/tc-or1k.h:
+	(tc_cfi_frame_initial_instructions) define.
+	(or1k_cfi_frame_initial_instructions) prototype (body in tc-or1k.c)
+	* config/tc-or1k.c:
+	(or1k_cfi_frame_initial_instructions) set SP as the default CFA reg.
+
 2012-12-29  Christian Svensson  <blue@cmd.nu>
 
 	* config/tc-or1k.h (TARGET_USE_CFIPOP): Enable CFI.

--- a/gas/config/tc-or1k.c
+++ b/gas/config/tc-or1k.c
@@ -27,6 +27,7 @@
 #include "opcodes/or1k-opc.h"
 #include "cgen.h"
 #include "elf/or1k.h"
+#include "dw2gencfi.h"
 
 /* Structure to hold all of the different components describing
    an individual instruction.  */
@@ -333,3 +334,11 @@ or1k_elf_final_processing (void)
   if (nodelay)
     elf_elfheader (stdoutput)->e_flags |= EF_OR1K_NODELAY;
 }
+
+/* Standard calling conventions leave the CFA at SP on entry.  */
+void
+or1k_cfi_frame_initial_instructions (void)
+{
+    cfi_add_CFA_def_cfa_register (1);
+}
+

--- a/gas/config/tc-or1k.h
+++ b/gas/config/tc-or1k.h
@@ -75,3 +75,6 @@ void or1k_elf_final_processing (void);
 /* or1k instructions are 4 bytes long.  */
 #define DWARF2_LINE_MIN_INSN_LENGTH 	4
 
+#define tc_cfi_frame_initial_instructions \
+    or1k_cfi_frame_initial_instructions
+extern void or1k_cfi_frame_initial_instructions (void);


### PR DESCRIPTION
Set default CFA to stack register.

Without this patch the default is not set and will cause a crash in unwind handlers in libgcc when DWARF2 is used for unwinding.

ChangeLog:
- config/tc-or1k.h:
  
  (tc_cfi_frame_initial_instructions) define.
  
  (or1k_cfi_frame_initial_instructions) prototype (body in tc-or1k.c)
- config/tc-or1k.c:
  
  (or1k_cfi_frame_initial_instructions) set SP as the default CFA reg.
