### PR TITLE
or1k: Correct mask for exception handling

### DIFF
--- a/newlib/ChangeLog.or1k
+++ b/newlib/ChangeLog.or1k
@@ -1,3 +1,6 @@
+2014-06-16  Stefan Wallentowitz  <stefan.wallentowitz@tum.de>
+	* libc/machine/or1k/or1k-support-asm.S: Correct mask for exception handling
+
 2014-04-22  Stefan Wallentowitz  <stefan.wallentowitz@tum.de>
 	* libc/machine/or1k/Makefile.am: Add mlock.c
 	* libc/machine/or1k/Makefile.in: ditto after automake

--- a/newlib/libc/machine/or1k/or1k-support-asm.S
+++ b/newlib/libc/machine/or1k/or1k-support-asm.S
@@ -636,7 +636,7 @@ or1k_exception_handler:
 	l.sw    0(r21), r20
 
 	/* Determine offset in table of exception handler using r3*/
-	l.andi	r13,r3,0xffff
+	l.andi	r13,r3,0xff00
 	l.srli	r13,r13,6
 	/* Substract 2 words, as we have no vector at 0 and no reset handler */
 	l.addi	r13,r13,-8


### PR DESCRIPTION
During exception handling we determine the actual exception by using
the program counter which was stored during the preamble at the
exception entry, e.g. 0x844 etc. This is the parameter to the
function. The shifting spared 2 positions to directly use the number *
4 for addressing in the vectors. But to do this properly (see
0x844>>6=0x21 instead of 0x20), we need to mask the lower 8 bits.
