### PR TITLE
or1k: Do not override section for non-TLS symbols.

### DIFF
--- a/bfd/elf32-or1k.c
+++ b/bfd/elf32-or1k.c
@@ -1120,6 +1120,8 @@ or1k_elf_relocate_section (bfd *output_bfd,
 	    bfd_byte *loc;
 	    int dynamic;
 
+	    sreloc = bfd_get_section_by_name (dynobj, ".rela.got");
+
 	    /* mark as TLS related GOT entry by setting 
 	     * bit 2 as well as bit 1 */
 	    if (h != NULL) 
@@ -1548,15 +1550,6 @@ or1k_elf_check_relocs (bfd *abfd,
 		htab->root.dynobj = dynobj = abfd;
 	      if (! create_got_section (dynobj, info))
 		return FALSE;
-	    }
-
-	  /* TLS specific */
-	  if (ELF32_R_TYPE (rel->r_info) >= R_OR1K_TLS_GD_HI16 &&
-	      ELF32_R_TYPE (rel->r_info) <= R_OR1K_TLS_IE_LO16)
-	    {
-	      /* set which rela section to use */
-	      elf_section_data (sec)->sreloc =
-		bfd_get_section_by_name (dynobj, ".rela.got");;
 	    }
 
 	  if (ELF32_R_TYPE (rel->r_info) != R_OR1K_GOTOFF_HI16 &&


### PR DESCRIPTION
Outgoing section for relocations was computed by setting a shared
pointer to which section should be used. For TLS this was overriden to
use .rela.got since they use GOT entries but since the pointer is per
section that whole section was relocated to .rela.got, even non-TLS
relocations.
- elf32-or1k.c: Fix a bug where non-TLS relocations would be forced
  into .rela.got if it contained TLS relocations as well.
