### PR TITLE
or1k: Set global timer period

### DIFF
--- a/newlib/ChangeLog.or1k
+++ b/newlib/ChangeLog.or1k
@@ -1,3 +1,6 @@
+2014-08-19  Stefan Wallentowitz  <stefan.wallentowitz@tum.de>
+	* libc/machine/or1k/or1k-support.c: Set global period variable
+
 2014-06-16  Stefan Wallentowitz  <stefan.wallentowitz@tum.de>
 	* libc/machine/or1k/or1k-support-asm.S: Correct mask for exception handling
 

--- a/newlib/libc/machine/or1k/or1k-support.c
+++ b/newlib/libc/machine/or1k/or1k-support.c
@@ -164,6 +164,7 @@ or1k_timer_init(unsigned int hz)
 
   /* Set this, for easy access when reloading */
   uint32_t period = (_board_clk_freq/hz) & SPR_TTMR_PERIOD;
+  or1k_timer_period = period;
   or1k_mtspr(SPR_TTMR, period);
 
   /* Reset timer tick counter */
@@ -186,6 +187,7 @@ or1k_timer_set_period(uint32_t hz)
     uint32_t ttmr = or1k_mfspr(SPR_TTMR);
     ttmr = (ttmr & ~SPR_TTMR_PERIOD) | period;
     or1k_mtspr(SPR_TTMR, ttmr);
+    or1k_timer_period = period;
 }
 
 void


### PR DESCRIPTION
This sets the global timer period (or1k_timer_period) on
initialization and when its explicitly set. Although the functions
should be used to reset the timer or set the period, this allows to
use legacy code that manually does this.
