### PR TITLE
Newlib: Only disable timer exception

### DIFF
--- a/newlib/libc/machine/or1k/or1k-support.c
+++ b/newlib/libc/machine/or1k/or1k-support.c
@@ -234,7 +234,6 @@ uint32_t
 or1k_timer_disable(void)
 {
     uint32_t sr = or1k_mfspr(SPR_SR);
-    or1k_mtspr(SPR_TTMR, or1k_mfspr(SPR_TTMR) & ~SPR_TTMR_IE);
     or1k_mtspr(SPR_SR, ~SPR_SR_TEE & sr);
     return (sr & SPR_SR_TEE);
 }


### PR DESCRIPTION
The code did not only disable the timer exception but also the
generation of the interrupt. This can lead to the effect, that the
timer silently reaches the match register value and continues
execution, without a pending interrupt. This is not what the user
expects.

Sorry for adding this originally..
