### PR TITLE
Fix Memory Size Of Atlys Board

### DIFF
--- a/libgloss/or1k/atlys.S
+++ b/libgloss/or1k/atlys.S
@@ -9,7 +9,7 @@
 .weak _board_clk_freq
 
 _board_mem_base:	.long	0x0
-_board_mem_size:	.long	0x2000000
+_board_mem_size:	.long	0x8000000
 
 _board_clk_freq:	.long	50000000
 


### PR DESCRIPTION
Fix Memory Size Of Atlys Board.32 MB  to 128 MB
