### PR TITLE
bfd/inline: Updates to allow building with gcc 5.x

### DIFF
--- a/bfd/ChangeLog
+++ b/bfd/ChangeLog
@@ -1,3 +1,15 @@
+2014-01-29  Nick Clifton  <nickc@redhat.com>
+
+       * bfd-in.h (bfd_set_section_vma): Delete.
+       (bfd_set_section_alignment): Delete.
+       (bfd_set_section_userdata): Delete.
+       (bfd_set_cacheable): Delete.
+       * bfd.c (bfd_set_cacheable): New static inline function.
+       * section.c (bfd_set_section_userdata): Likewise.
+       (bfd_set_section_vma): Likewise.
+       (bfd_set_section_alignment): Likewise.
+       * bfd-in2.h: Regenerate.
+
 2014-08-13  Stefan Kristiansson  <stefan.kristiansson@saunalahti.fi>
 
 	* elf32-or1k.c (or1k_elf_relocate_section, or1k_elf_check_relocs,

--- a/bfd/bfd-in.h
+++ b/bfd/bfd-in.h
@@ -292,9 +292,6 @@ typedef struct bfd_section *sec_ptr;
 
 #define bfd_is_com_section(ptr) (((ptr)->flags & SEC_IS_COMMON) != 0)
 
-#define bfd_set_section_vma(bfd, ptr, val) (((ptr)->vma = (ptr)->lma = (val)), ((ptr)->user_set_vma = TRUE), TRUE)
-#define bfd_set_section_alignment(bfd, ptr, val) (((ptr)->alignment_power = (val)),TRUE)
-#define bfd_set_section_userdata(bfd, ptr, val) (((ptr)->userdata = (val)),TRUE)
 /* Find the address one past the end of SEC.  */
 #define bfd_get_section_limit(bfd, sec) \
   (((bfd)->direction != write_direction && (sec)->rawsize != 0	\
@@ -516,8 +513,6 @@ extern void warn_deprecated (const char *, const char *, int, const char *);
 #define bfd_get_dynamic_symcount(abfd) ((abfd)->dynsymcount)
 
 #define bfd_get_symbol_leading_char(abfd) ((abfd)->xvec->symbol_leading_char)
-
-#define bfd_set_cacheable(abfd,bool) (((abfd)->cacheable = bool), TRUE)
 
 extern bfd_boolean bfd_cache_close
   (bfd *abfd);

--- a/bfd/bfd-in2.h
+++ b/bfd/bfd-in2.h
@@ -299,9 +299,6 @@ typedef struct bfd_section *sec_ptr;
 
 #define bfd_is_com_section(ptr) (((ptr)->flags & SEC_IS_COMMON) != 0)
 
-#define bfd_set_section_vma(bfd, ptr, val) (((ptr)->vma = (ptr)->lma = (val)), ((ptr)->user_set_vma = TRUE), TRUE)
-#define bfd_set_section_alignment(bfd, ptr, val) (((ptr)->alignment_power = (val)),TRUE)
-#define bfd_set_section_userdata(bfd, ptr, val) (((ptr)->userdata = (val)),TRUE)
 /* Find the address one past the end of SEC.  */
 #define bfd_get_section_limit(bfd, sec) \
   (((bfd)->direction != write_direction && (sec)->rawsize != 0	\
@@ -523,8 +520,6 @@ extern void warn_deprecated (const char *, const char *, int, const char *);
 #define bfd_get_dynamic_symcount(abfd) ((abfd)->dynsymcount)
 
 #define bfd_get_symbol_leading_char(abfd) ((abfd)->xvec->symbol_leading_char)
-
-#define bfd_set_cacheable(abfd,bool) (((abfd)->cacheable = bool), TRUE)
 
 extern bfd_boolean bfd_cache_close
   (bfd *abfd);
@@ -1029,7 +1024,7 @@ bfd *bfd_openr (const char *filename, const char *target);
 
 bfd *bfd_fdopenr (const char *filename, const char *target, int fd);
 
-bfd *bfd_openstreamr (const char *, const char *, void *);
+bfd *bfd_openstreamr (const char * filename, const char * target, void * stream);
 
 bfd *bfd_openr_iovec (const char *filename, const char *target,
     void *(*open_func) (struct bfd *nbfd,
@@ -1593,6 +1588,32 @@ struct relax_table {
   /* Number of bytes to be deleted.  */
   int size;
 };
+
+/* Note: the following are provided as inline functions rather than macros
+   because not all callers use the return value.  A macro implementation
+   would use a comma expression, eg: "((ptr)->foo = val, TRUE)" and some
+   compilers will complain about comma expressions that have no effect.  */
+static inline bfd_boolean
+bfd_set_section_userdata (bfd * abfd ATTRIBUTE_UNUSED, asection * ptr, void * val)
+{
+  ptr->userdata = val;
+  return TRUE;
+}
+
+static inline bfd_boolean
+bfd_set_section_vma (bfd * abfd ATTRIBUTE_UNUSED, asection * ptr, bfd_vma val)
+{
+  ptr->vma = ptr->lma = val;
+  ptr->user_set_vma = TRUE;
+  return TRUE;
+}
+
+static inline bfd_boolean
+bfd_set_section_alignment (bfd * abfd ATTRIBUTE_UNUSED, asection * ptr, unsigned int val)
+{
+  ptr->alignment_power = val;
+  return TRUE;
+}
 
 /* These sections are global, and are managed by BFD.  The application
    and target back end are not permitted to change the values in
@@ -6250,6 +6271,14 @@ struct bfd
      this object.  Used by VMS linkers.  */
   unsigned int selective_search : 1;
 };
+
+/* See note beside bfd_set_section_userdata.  */
+static inline bfd_boolean
+bfd_set_cacheable (bfd * abfd, bfd_boolean val)
+{
+  abfd->cacheable = val;
+  return TRUE;
+}
 
 typedef enum bfd_error
 {

--- a/bfd/bfd.c
+++ b/bfd/bfd.c
@@ -311,6 +311,14 @@ CODE_FRAGMENT
 .  unsigned int selective_search : 1;
 .};
 .
+.{* See note beside bfd_set_section_userdata.  *}
+.static inline bfd_boolean
+.bfd_set_cacheable (bfd * abfd, bfd_boolean val)
+.{
+.  abfd->cacheable = val;
+.  return TRUE;
+.}
+.
 */
 
 #include "sysdep.h"

--- a/bfd/section.c
+++ b/bfd/section.c
@@ -542,6 +542,32 @@ CODE_FRAGMENT
 .  int size;
 .};
 .
+.{* Note: the following are provided as inline functions rather than macros
+.   because not all callers use the return value.  A macro implementation
+.   would use a comma expression, eg: "((ptr)->foo = val, TRUE)" and some
+.   compilers will complain about comma expressions that have no effect.  *}
+.static inline bfd_boolean
+.bfd_set_section_userdata (bfd * abfd ATTRIBUTE_UNUSED, asection * ptr, void * val)
+.{
+.  ptr->userdata = val;
+.  return TRUE;
+.}
+.
+.static inline bfd_boolean
+.bfd_set_section_vma (bfd * abfd ATTRIBUTE_UNUSED, asection * ptr, bfd_vma val)
+.{
+.  ptr->vma = ptr->lma = val;
+.  ptr->user_set_vma = TRUE;
+.  return TRUE;
+.}
+.
+.static inline bfd_boolean
+.bfd_set_section_alignment (bfd * abfd ATTRIBUTE_UNUSED, asection * ptr, unsigned int val)
+.{
+.  ptr->alignment_power = val;
+.  return TRUE;
+.}
+.
 .{* These sections are global, and are managed by BFD.  The application
 .   and target back end are not permitted to change the values in
 .   these sections.  *}

--- a/sim/common/ChangeLog
+++ b/sim/common/ChangeLog
@@ -1,3 +1,9 @@
+2015-03-29  Mike Frysinger  <vapier@gentoo.org>
+
+       * sim-arange.h (SIM_ARANGE_INLINE): Move above sim_addr_range_hit_p.
+       (sim_addr_range_hit_p): Change INLINE to SIM_ARANGE_INLINE.
+       * sim-inline.h (INLINE2): Define to gnu_inline when available.
+
 2013-09-23  Alan Modra  <amodra@gmail.com>
 
 	* configure: Regenerate.

--- a/sim/common/cgen-mem.h
+++ b/sim/common/cgen-mem.h
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 #ifdef MEMOPS_DEFINE_INLINE
 #define MEMOPS_INLINE
 #else
-#define MEMOPS_INLINE extern inline
+#define MEMOPS_INLINE EXTERN_INLINE
 #endif
 
 /* Integer memory read support.

--- a/sim/common/cgen-ops.h
+++ b/sim/common/cgen-ops.h
@@ -26,7 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #if defined (__GNUC__) && ! defined (SEMOPS_DEFINE_INLINE)
 #define SEMOPS_DEFINE_INLINE
-#define SEMOPS_INLINE extern inline
+#define SEMOPS_INLINE EXTERN_INLINE
 #else
 #define SEMOPS_INLINE
 #endif

--- a/sim/common/gentmap.c
+++ b/sim/common/gentmap.c
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 struct tdefs {
   char *symbol;

--- a/sim/common/sim-arange.h
+++ b/sim/common/sim-arange.h
@@ -60,22 +60,26 @@ extern void sim_addr_range_delete (ADDR_RANGE * /*ar*/,
 				   address_word /*start*/,
 				   address_word /*end*/);
 
-/* Return non-zero if ADDR is in range AR, traversing the entire tree.
-   If no range is specified, that is defined to mean "everything".  */
-extern INLINE int
-sim_addr_range_hit_p (ADDR_RANGE * /*ar*/, address_word /*addr*/);
-#define ADDR_RANGE_HIT_P(ar, addr) \
-  ((ar)->range_tree == NULL || sim_addr_range_hit_p ((ar), (addr)))
-
+/* TODO: This should get moved into sim-inline.h.  */
 #ifdef HAVE_INLINE
 #ifdef SIM_ARANGE_C
 #define SIM_ARANGE_INLINE INLINE
 #else
 #define SIM_ARANGE_INLINE EXTERN_INLINE
 #endif
-#include "sim-arange.c"
 #else
-#define SIM_ARANGE_INLINE
+#define SIM_ARANGE_INLINE EXTERN
+#endif
+
+/* Return non-zero if ADDR is in range AR, traversing the entire tree.
+   If no range is specified, that is defined to mean "everything".  */
+SIM_ARANGE_INLINE int
+sim_addr_range_hit_p (ADDR_RANGE * /*ar*/, address_word /*addr*/);
+#define ADDR_RANGE_HIT_P(ar, addr) \
+  ((ar)->range_tree == NULL || sim_addr_range_hit_p ((ar), (addr)))
+
+#ifdef HAVE_INLINE
+#include "sim-arange.c"
 #endif
 #define SIM_ARANGE_C_INCLUDED
 

--- a/sim/common/sim-inline.h
+++ b/sim/common/sim-inline.h
@@ -303,7 +303,9 @@
 /* ??? Temporary, pending decision to always use extern inline and do a vast
    cleanup of inline support.  */
 #ifndef INLINE2
-#if defined (__GNUC__)
+#if defined (__GNUC_GNU_INLINE__) || defined (__GNUC_STDC_INLINE__)
+#define INLINE2 __inline__ __attribute__ ((__gnu_inline__))
+#elif defined (__GNUC__)
 #define INLINE2 __inline__
 #else
 #define INLINE2 /*inline*/


### PR DESCRIPTION
Fixing 2 main issues, pulled from upstream:
- Nick Clifton: I am checking in a patch to replace the various
  bfd_xxx_set macros with static inline functions, so that we can avoid
  compile time warnings about comma expressions with unused values.
- Mike Frysinger: fix issues with new extern inline symatics causing
  multiple definition errors
